### PR TITLE
[FE] theme 색상 추가 및 변경 / Button과 Label hover 스타일 변경

### DIFF
--- a/src/components/Button/style.ts
+++ b/src/components/Button/style.ts
@@ -23,7 +23,8 @@ const outlineButtonStyle = css`
   color: ${({ theme }) => theme.color.accent.text.strong};
 
   &:hover {
-    border: 0.0625rem solid ${({ theme }) => theme.palette.green200};
+    opacity: 0.9;
+    background-color: ${({ theme }) => theme.palette.green100};
   }
 `;
 

--- a/src/components/Button/style.ts
+++ b/src/components/Button/style.ts
@@ -3,27 +3,27 @@ import styled, { css } from 'styled-components';
 const defaultButtonStyle = css`
   padding: 0.75rem 1.25rem;
   background-color: ${({ theme }) => theme.color.accent.bg.default};
-  border: 0.125rem solid transparent;
+  border: 0.0625rem solid transparent;
   border-radius: 0.75rem;
 
   color: ${({ theme }) => theme.color.neutral.text.weak};
 
   &:hover {
     opacity: 0.9;
-    border: 0.125rem solid ${({ theme }) => theme.palette.green200};
+    border: 0.0625rem solid ${({ theme }) => theme.palette.green200};
   }
 `;
 
 const outlineButtonStyle = css`
   padding: 0.75rem 1.25rem;
   background-color: ${({ theme }) => theme.color.neutral.bg.default};
-  border: 0.125rem solid ${({ theme }) => theme.color.accent.bd.strong};
+  border: 0.0625rem solid ${({ theme }) => theme.color.accent.bd.strong};
   border-radius: 0.75rem;
 
   color: ${({ theme }) => theme.color.accent.text.strong};
 
   &:hover {
-    border: 0.125rem solid ${({ theme }) => theme.palette.green200};
+    border: 0.0625rem solid ${({ theme }) => theme.palette.green200};
   }
 `;
 

--- a/src/components/Label/style.ts
+++ b/src/components/Label/style.ts
@@ -8,6 +8,10 @@ const defaultLabelStyle = css`
   & > svg {
     fill: ${({ theme }) => theme.color.neutral.text.default};
   }
+  &:hover {
+    opacity: 0.9;
+    background-color: ${({ theme }) => theme.palette.green100};
+  }
 `;
 
 const activeLabelStyle = css`
@@ -17,6 +21,9 @@ const activeLabelStyle = css`
 
   & > svg {
     fill: ${({ theme }) => theme.color.neutral.text.weak};
+  }
+  &:hover {
+    opacity: 0.9;
   }
 `;
 
@@ -30,10 +37,6 @@ const LabelLayout = styled.button<{ $isActive: boolean; $px: string; $py: string
 
   ${({ $isActive }) => ($isActive ? activeLabelStyle : defaultLabelStyle)}
   ${({ theme }) => theme.font.label}
-  
-  &:hover {
-    border: 0.125rem solid ${({ theme }) => theme.palette.green200};
-  }
 `;
 
 export { LabelLayout };

--- a/src/components/Label/style.ts
+++ b/src/components/Label/style.ts
@@ -13,10 +13,10 @@ const defaultLabelStyle = css`
 const activeLabelStyle = css`
   background-color: ${({ theme }) => theme.color.accent.bg.default};
   border: 0.125rem solid transparent;
-  color: ${({ theme }) => theme.palette.white};
+  color: ${({ theme }) => theme.color.neutral.text.weak};
 
   & > svg {
-    fill: ${({ theme }) => theme.palette.white};
+    fill: ${({ theme }) => theme.color.neutral.text.weak};
   }
 `;
 

--- a/src/stories/Icon.stories.tsx
+++ b/src/stories/Icon.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 
-import { ComponentList, ComponentListItem, ComponentTable, Th, Tr } from '@styles/storyStyle';
+import { ComponentList, ComponentListItem } from '@styles/storyStyle';
 
 import Icon from '@components/Icon/Icon';
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -88,6 +88,7 @@ const palette = {
   red: '#FF3B30',
   navy: '#0025E6',
   white: '#FFFFFF',
+  black: '#000000',
   green50: '#F8FBF4',
   green100: '#D8F3DC',
   green200: '#B7E4C7',
@@ -114,9 +115,9 @@ const color = {
   neutral: {
     text: {
       weak: palette.white,
-      default: palette.grey800,
+      default: palette.grey900,
       sub: palette.grey400,
-      strong: palette.grey900,
+      strong: palette.black,
     },
     bg: {
       default: palette.white,


### PR DESCRIPTION
## 개요

text의 기본 색상을 더 짙게 변경하고, Button과 Label를 hover했을 때의 스타일을 수정했다.

## 작업 사항

- palette에 black 색상 추가
- `color.neutral.text.default`와  `color.neutral.text.strong` 색상 변경
- Button을 hover했을 때 스타일 재설정
- Label을 hover했을 때 스타일 재설정

## 이슈 번호

close #20 
