### PR TITLE
[FE] Select 컴포넌트에서 선택된 option의 name 빼기

### DIFF
--- a/src/components/Select/OptionItem.tsx
+++ b/src/components/Select/OptionItem.tsx
@@ -1,29 +1,28 @@
-import React, { ComponentPropsWithRef, PropsWithChildren, forwardRef } from 'react';
+import React, { ComponentPropsWithRef } from 'react';
 
 import { useOptionContext } from '@contexts/OptionContext';
 
-import { Name, Value } from './Select.types';
+import { Value } from './Select.types';
 import { OptionItem as OptionItemLayout } from './style';
 
 export interface Props extends ComponentPropsWithRef<'li'> {
   value: Value;
-  name: Name;
 }
 
-const OptionItem = forwardRef<HTMLLIElement, PropsWithChildren<Props>>(({ value, name, children }, ref) => {
-  const { selectedOption, onSelectOption } = useOptionContext();
+const OptionItem = ({ value, children }: Props) => {
+  const { selectedOption, onSelectOption, setListItemsRef } = useOptionContext();
 
   return (
     <OptionItemLayout
-      ref={ref}
+      ref={setListItemsRef}
       value={value}
       $isSelected={selectedOption?.value === value}
-      onMouseDown={() => onSelectOption({ value, name })}
+      onMouseDown={() => onSelectOption({ value })}
     >
       {children}
     </OptionItemLayout>
   );
-});
+};
 
 OptionItem.displayName = 'OptionItem';
 

--- a/src/components/Select/OptionList.tsx
+++ b/src/components/Select/OptionList.tsx
@@ -15,10 +15,13 @@ const OptionList = ({ children, maxHeight }: PropsWithChildren<Props>) => {
 
   useOutsideClick({ listRef, triggerRef, isOpen, onClick: () => onOpenChange(false) });
 
-  if (!isOpen) return null;
-
   return (
-    <OptionListLayout ref={listRef} $maxHeight={maxHeight} onClick={() => onOpenChange(false)}>
+    <OptionListLayout
+      ref={listRef}
+      $maxHeight={maxHeight}
+      $isOpen={isOpen}
+      onClick={() => onOpenChange(false)}
+    >
       {children}
     </OptionListLayout>
   );

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -1,13 +1,8 @@
 /**
- * Name: option에 표시할 text
- */
-export type Name = number | string;
-/**
  * Value: option의 value
  */
 export type Value = number | string;
 
 export interface Option {
   value: Value;
-  name: Name;
 }

--- a/src/components/Select/TriggerButton.tsx
+++ b/src/components/Select/TriggerButton.tsx
@@ -16,7 +16,7 @@ export interface Props extends ComponentPropsWithRef<'button'> {
 
 const TriggerButton = forwardRef<HTMLButtonElement, Props>(({ label, height = 'fit-content' }, ref) => {
   const { isOpen, onOpenChange, triggerRef } = useSelectContext();
-  const { selectedOption } = useOptionContext();
+  const { selectedOptionName } = useOptionContext();
 
   const buttonRef = useSyncRef(triggerRef, ref);
 
@@ -28,7 +28,7 @@ const TriggerButton = forwardRef<HTMLButtonElement, Props>(({ label, height = 'f
         onOpenChange(!isOpen);
       }}
     >
-      <SelectedValue>{`${selectedOption?.name ?? label ?? ''}`}</SelectedValue>
+      <SelectedValue>{`${selectedOptionName ?? label ?? ''}`}</SelectedValue>
       {isOpen ? <Icon iconName="upArrow" /> : <Icon iconName="downArrow" />}
     </TriggerButtonLayout>
   );

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -29,8 +29,8 @@ const SelectedValue = styled.span`
   ${({ theme }) => theme.font.body.default}
 `;
 
-const OptionList = styled.ul<{ $maxHeight?: string }>`
-  display: flex;
+const OptionList = styled.ul<{ $maxHeight?: string; $isOpen: boolean }>`
+  display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
   flex-direction: column;
   width: 100%;
   min-width: 5.625rem;

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 
 import Select from '@components/Select/Select';
-import { Option } from '@components/Select/Select.types';
+// import { Option } from '@components/Select/Select.types';
 
 const meta: Meta<typeof Select> = {
   title: 'Select',
@@ -11,7 +11,7 @@ const meta: Meta<typeof Select> = {
   tags: ['autodocs'],
   argTypes: {
     defaultOption: {
-      description: '기본으로 선택된 option입니다. (name: option의 text, value: option의 value)',
+      description: '기본으로 선택된 option입니다. (value: option의 value)',
       control: 'object',
     },
     onSelectOption: {
@@ -29,7 +29,7 @@ const meta: Meta<typeof Select> = {
     docs: {
       description: {
         component:
-          'Select 컴포넌트는 Compound Component Pattern을 적용합니다. `<Select.TriggerButton>` 혹은 `<Select.TriggerInput>` 다음에 `<Select.OptionList>`를 선언해주세요.\n- `<Select.TriggerButton>`은 option 목록을 여닫는 버튼 컴포넌트입니다.\n- `<Select.TriggerInput>`은 입력한 검색어에 해당하는 option 목록을 보여주는 input 컴포넌트입니다.\n- `<Select.OptionList>`는 option 목록에 해당하는 컴포넌트입니다. maxHeight prop을 통해 높이를 정할 수 있습니다.\n- `<Select.OptionItem>`은 option에 해당하는 컴포넌트입니다. prop으로 value에 option의 value를, name에 option의 text를 입력해주세요.',
+          'Select 컴포넌트는 Compound Component Pattern을 적용합니다. `<Select.TriggerButton>` 다음에 `<Select.OptionList>`를 선언해주세요.\n- `<Select.TriggerButton>`은 option 목록을 여닫는 버튼 컴포넌트입니다.\n- `<Select.TriggerInput>`은 입력한 검색어에 해당하는 option 목록을 보여주는 input 컴포넌트입니다.\n- `<Select.OptionList>`는 option 목록에 해당하는 컴포넌트입니다. maxHeight prop을 통해 높이를 정할 수 있습니다.\n- `<Select.OptionItem>`은 option에 해당하는 컴포넌트입니다. prop으로 value에 option의 value를, name에 option의 text를 입력해주세요.',
       },
     },
   },
@@ -41,7 +41,7 @@ type Story = StoryObj<typeof Select>;
 
 export const Default: Story = {
   render: () => {
-    const [, setSelectedOption] = useState<Option | undefined>();
+    const [, setSelectedOption] = useState<{ value: string } | undefined>();
     const options = [
       { value: 'apple', name: '사과' },
       { value: 'graph', name: '포도' },
@@ -49,12 +49,16 @@ export const Default: Story = {
     ];
 
     return (
-      <Select onSelectOption={setSelectedOption}>
+      <Select
+        onSelectOption={(option) => {
+          if (option && typeof option.value === 'string') setSelectedOption({ value: option.value });
+        }}
+      >
         <Select.TriggerButton />
         <Select.OptionList>
           {options.map((option) => {
             return (
-              <Select.OptionItem key={option.value} value={option.value} name={option.name}>
+              <Select.OptionItem key={option.value} value={option.value}>
                 {option.name}
               </Select.OptionItem>
             );
@@ -74,7 +78,7 @@ export const DefaultOption: Story = {
     },
   },
   render: () => {
-    const [, setSelectedOption] = useState<Option | undefined>();
+    const [, setSelectedOption] = useState<{ value: string } | undefined>();
     const options = [
       { value: 'apple', name: '사과' },
       { value: 'graph', name: '포도' },
@@ -83,12 +87,17 @@ export const DefaultOption: Story = {
     const defaultOption = options[1];
 
     return (
-      <Select defaultOption={defaultOption} onSelectOption={setSelectedOption}>
+      <Select
+        defaultOption={defaultOption}
+        onSelectOption={(option) => {
+          if (option && typeof option.value === 'string') setSelectedOption({ value: option.value });
+        }}
+      >
         <Select.TriggerButton />
         <Select.OptionList>
           {options.map((option) => {
             return (
-              <Select.OptionItem key={option.value} value={option.value} name={option.name}>
+              <Select.OptionItem key={option.value} value={option.value}>
                 {option.name}
               </Select.OptionItem>
             );


### PR DESCRIPTION
## 개요

기존 Select 컴포넌트를 사용할 때, 선택된 option의 관한 정보를 value와 name 프로퍼티가 있는 객체로 넘겨줘야 했었다.
또한 각 OptionItem마다 prop으로 name 값을 넘겨줘야했다.
사용자가 name을 설정하는 대신에 ref 콜백을 활용하여 추상화를 시도해봤다.

## 작업 사항

- Select 관련 type에 name 빼기
- OptionItem들의 ref를 저장하고 있는 ref callback 생성
- 변경된 부분 storybook에 반영

## 이슈 번호

close #66 