### PR TITLE
[FE] select 컴포넌트에서 Value 타입 삭제

### DIFF
--- a/src/components/Select/OptionItem.tsx
+++ b/src/components/Select/OptionItem.tsx
@@ -2,22 +2,22 @@ import React, { ComponentPropsWithRef } from 'react';
 
 import { useOptionContext } from '@contexts/OptionContext';
 
-import { Value } from './Select.types';
+import { Option } from './Select.types';
 import { OptionItem as OptionItemLayout } from './style';
 
 export interface Props extends ComponentPropsWithRef<'li'> {
-  value: Value;
+  option: Option;
 }
 
-const OptionItem = ({ value, children }: Props) => {
+const OptionItem = ({ option, children }: Props) => {
   const { selectedOption, onSelectOption, setListItemsRef } = useOptionContext();
 
   return (
     <OptionItemLayout
       ref={setListItemsRef}
-      value={value}
-      $isSelected={selectedOption?.value === value}
-      onMouseDown={() => onSelectOption({ value })}
+      value={option}
+      $isSelected={selectedOption === option}
+      onMouseDown={() => onSelectOption(option)}
     >
       {children}
     </OptionItemLayout>

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -1,8 +1,1 @@
-/**
- * Value: option의 value
- */
-export type Value = number | string;
-
-export interface Option {
-  value: Value;
-}
+export type Option = number | string;

--- a/src/contexts/OptionContext.tsx
+++ b/src/contexts/OptionContext.tsx
@@ -49,7 +49,10 @@ const OptionProvider = ({ store, children }: OptionProviderType) => {
   };
 
   useEffect(() => {
-    const selectedOptionName = listItemsRef.current?.get(selectedOption?.value ?? '')?.textContent ?? '';
+    if (selectedOption === undefined) return;
+
+    const selectedOptionName = getListItemsRef().get(selectedOption)?.textContent || '';
+
     setSelectedOptionName(selectedOptionName);
   }, [selectedOption]);
 

--- a/src/stories/Select.stories.tsx
+++ b/src/stories/Select.stories.tsx
@@ -11,8 +11,7 @@ const meta: Meta<typeof Select> = {
   tags: ['autodocs'],
   argTypes: {
     defaultOption: {
-      description: '기본으로 선택된 option입니다. (value: option의 value)',
-      control: 'object',
+      description: '기본으로 선택된 option입니다.',
     },
     onSelectOption: {
       description: 'option을 선택했을 때의 handler입니다.',
@@ -41,24 +40,24 @@ type Story = StoryObj<typeof Select>;
 
 export const Default: Story = {
   render: () => {
-    const [, setSelectedOption] = useState<{ value: string } | undefined>();
+    const [, setSelectedOption] = useState<string | undefined>();
     const options = [
-      { value: 'apple', name: '사과' },
-      { value: 'graph', name: '포도' },
-      { value: 'banana', name: '바나나' },
+      { id: 'apple', name: '사과' },
+      { id: 'graph', name: '포도' },
+      { id: 'banana', name: '바나나' },
     ];
 
     return (
       <Select
         onSelectOption={(option) => {
-          if (option && typeof option.value === 'string') setSelectedOption({ value: option.value });
+          if (option && typeof option === 'string') setSelectedOption(option);
         }}
       >
         <Select.TriggerButton />
         <Select.OptionList>
           {options.map((option) => {
             return (
-              <Select.OptionItem key={option.value} value={option.value}>
+              <Select.OptionItem key={option.id} option={option.id}>
                 {option.name}
               </Select.OptionItem>
             );
@@ -78,26 +77,26 @@ export const DefaultOption: Story = {
     },
   },
   render: () => {
-    const [, setSelectedOption] = useState<{ value: string } | undefined>();
     const options = [
       { value: 'apple', name: '사과' },
       { value: 'graph', name: '포도' },
       { value: 'banana', name: '바나나' },
     ];
     const defaultOption = options[1];
+    const [, setSelectedOption] = useState<string | undefined>(defaultOption.value);
 
     return (
       <Select
-        defaultOption={defaultOption}
+        defaultOption={defaultOption.value}
         onSelectOption={(option) => {
-          if (option && typeof option.value === 'string') setSelectedOption({ value: option.value });
+          if (option && typeof option === 'string') setSelectedOption(option);
         }}
       >
         <Select.TriggerButton />
         <Select.OptionList>
           {options.map((option) => {
             return (
-              <Select.OptionItem key={option.value} value={option.value}>
+              <Select.OptionItem key={option.value} option={option.value}>
                 {option.name}
               </Select.OptionItem>
             );


### PR DESCRIPTION
## 개요

기존에 선택된 option을 `{ value }` 객체 타입의 상태로 관리하고 있었는데, 원시값으로 관리하는 것으로 변경했다.

## 작업 사항

- Value 타입 삭제
- Option 타입을 이용하여 서브 컴포넌트 수정
- Select 컴포넌트 storybook 수정

## 이슈 번호

close #74 