### PR TITLE
[FE] Multi Range Slider 리팩토링

### DIFF
--- a/src/components/MultiRangeSlider/MultiRangeSlider.tsx
+++ b/src/components/MultiRangeSlider/MultiRangeSlider.tsx
@@ -14,9 +14,20 @@ interface Props {
   step?: number;
   range: Range;
   onRangeChange: ({ min, max }: Range) => void;
+  hasGreaterCheck?: boolean;
+  hasLessCheck?: boolean;
 }
 
-const MultiRangeSlider = ({ width, min, max, step = 1, range, onRangeChange }: Props) => {
+const MultiRangeSlider = ({
+  width,
+  min,
+  max,
+  step = 1,
+  range,
+  onRangeChange,
+  hasGreaterCheck,
+  hasLessCheck,
+}: Props) => {
   const getPercent = (value: number) => {
     return Math.round(((value - min) / (max - min)) * 100);
   };
@@ -60,8 +71,10 @@ const MultiRangeSlider = ({ width, min, max, step = 1, range, onRangeChange }: P
       <Slider>
         <Track />
         <Range $left={`${minPercent}%`} $width={`${maxPercent - minPercent}%`} />
-        <LeftValue $left={`${minPercent}%`}>{range.min}</LeftValue>
-        <RightValue $right={`${100 - maxPercent}%`}>{range.max}</RightValue>
+        <LeftValue $left={`${minPercent}%`}>{hasLessCheck ? `${range.min}-` : range.min}</LeftValue>
+        <RightValue $right={`${100 - maxPercent}%`}>
+          {hasGreaterCheck ? `${range.max}+` : range.max}
+        </RightValue>
       </Slider>
     </MultiRangeSliderLayout>
   );

--- a/src/components/MultiRangeSlider/MultiRangeSlider.tsx
+++ b/src/components/MultiRangeSlider/MultiRangeSlider.tsx
@@ -71,8 +71,8 @@ const MultiRangeSlider = ({
       <Slider>
         <Track />
         <Range $left={`${minPercent}%`} $width={`${maxPercent - minPercent}%`} />
-        <MinValue>{hasLessCheck ? `${min}-` : min}</MinValue>
-        <MaxValue>{hasGreaterCheck ? `${max}+` : max}</MaxValue>
+        <MinValue>{hasLessCheck ? `${min} -` : min}</MinValue>
+        <MaxValue>{hasGreaterCheck ? `${max} +` : max}</MaxValue>
       </Slider>
     </MultiRangeSliderLayout>
   );

--- a/src/components/MultiRangeSlider/MultiRangeSlider.tsx
+++ b/src/components/MultiRangeSlider/MultiRangeSlider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LeftValue, MultiRangeSliderLayout, Range, RightValue, Slider, Thumb, Track } from './style';
+import { MinValue, MultiRangeSliderLayout, Range, MaxValue, Slider, Thumb, Track } from './style';
 
 interface Range {
   min: number;
@@ -71,10 +71,8 @@ const MultiRangeSlider = ({
       <Slider>
         <Track />
         <Range $left={`${minPercent}%`} $width={`${maxPercent - minPercent}%`} />
-        <LeftValue $left={`${minPercent}%`}>{hasLessCheck ? `${range.min}-` : range.min}</LeftValue>
-        <RightValue $right={`${100 - maxPercent}%`}>
-          {hasGreaterCheck ? `${range.max}+` : range.max}
-        </RightValue>
+        <MinValue>{hasLessCheck ? `${min}-` : min}</MinValue>
+        <MaxValue>{hasGreaterCheck ? `${max}+` : max}</MaxValue>
       </Slider>
     </MultiRangeSliderLayout>
   );

--- a/src/components/MultiRangeSlider/style.ts
+++ b/src/components/MultiRangeSlider/style.ts
@@ -23,6 +23,7 @@ const Thumb = styled.input`
   position: absolute;
   width: 100%;
   top: ${THUMB_TOP}rem;
+  left: 0;
 
   // 기본 스타일 초기화
   -webkit-appearance: none;

--- a/src/components/MultiRangeSlider/style.ts
+++ b/src/components/MultiRangeSlider/style.ts
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { theme } from '@styles/theme';
 
-const THUMB_SIZE = 2;
+const THUMB_SIZE = 1.75;
 const THUMB_TOP = -0.75;
 
 const MultiRangeSliderLayout = styled.div<{ $width?: string }>`
@@ -14,8 +14,13 @@ const thumbStyles = css`
   width: ${THUMB_SIZE}rem;
   height: ${THUMB_SIZE}rem;
 
+  background-color: ${theme.color.neutral.bg.default};
+  border: 2px solid ${theme.color.accent.bd.strong};
+  border-radius: 50%;
+
   &:active {
     cursor: grabbing;
+    outline: blue;
   }
 `;
 
@@ -27,11 +32,12 @@ const Thumb = styled.input`
 
   // 기본 스타일 초기화
   -webkit-appearance: none;
+  -moz-appearance: none;
   // 가려진 input 이벤트 비활성화
   pointer-events: none;
+  background: none;
 
   z-index: 2;
-  opacity: 0;
 
   &::-webkit-slider-thumb {
     // thumb 스타일 초기화
@@ -43,6 +49,7 @@ const Thumb = styled.input`
     ${thumbStyles}
   }
   &::-moz-range-thumb {
+    -moz-appearance: none;
     pointer-events: all;
     cursor: pointer;
 
@@ -77,19 +84,14 @@ const Range = styled.div<{ $left: string; $width: string }>`
   bottom: 0;
 
   background-color: ${theme.color.accent.bg.strong};
+  border-radius: 0.5rem;
 
   z-index: 2;
 `;
 
 const valueStyles = css`
   position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  background-color: ${theme.color.neutral.bg.default};
-  border: 2px solid ${theme.color.accent.bd.strong};
-  border-radius: 50%;
+  top: 1rem;
 
   ${theme.font.body.default}
   color: ${theme.color.neutral.text.default};
@@ -98,22 +100,14 @@ const valueStyles = css`
   z-index: 3;
 `;
 
-const LeftValue = styled.div<{ $left: string }>`
+const MinValue = styled.div`
   ${valueStyles}
-  top: ${THUMB_TOP}rem;
-  left: ${({ $left }) => $left};
-  transform: translateX(-50%);
-
-  ${thumbStyles}
+  left: 0;
 `;
 
-const RightValue = styled.div<{ $right: string }>`
+const MaxValue = styled.div`
   ${valueStyles}
-  top: ${THUMB_TOP}rem;
-  right: ${({ $right }) => $right};
-  transform: translateX(50%);
-
-  ${thumbStyles}
+  right: 0;
 `;
 
-export { MultiRangeSliderLayout, Thumb, Slider, Track, Range, LeftValue, RightValue };
+export { MultiRangeSliderLayout, Thumb, Slider, Track, Range, MinValue, MaxValue };

--- a/src/stories/MultiRangeSlider.stories.tsx
+++ b/src/stories/MultiRangeSlider.stories.tsx
@@ -29,6 +29,14 @@ const meta: Meta<typeof MultiRangeSlider> = {
       description: '슬라이더의 범위를 설정합니다. 범위의 최솟값과 최댓값을 객체로 설정합니다.',
       control: 'object',
     },
+    hasGreaterCheck: {
+      description: '범위의 최댓값과 max가 동일하면, + 표시할건지 여부를 설정합니다.',
+      control: 'boolean',
+    },
+    hasLessCheck: {
+      description: '범위의 최솟값과 min이 동일하면, - 표시할건지 여부를 설정합니다.',
+      control: 'boolean',
+    },
   },
 };
 
@@ -37,11 +45,20 @@ export default meta;
 type Story = StoryObj<typeof MultiRangeSlider>;
 
 export const Default: Story = {
-  render: ({ width, step }) => {
+  render: ({ width, step, hasGreaterCheck, hasLessCheck }) => {
     const [range, setRange] = useState({ min: 0, max: 10 });
 
     return (
-      <MultiRangeSlider width={width} step={step} min={0} max={10} range={range} onRangeChange={setRange} />
+      <MultiRangeSlider
+        width={width}
+        step={step}
+        min={0}
+        max={10}
+        range={range}
+        onRangeChange={setRange}
+        hasGreaterCheck={hasGreaterCheck}
+        hasLessCheck={hasLessCheck}
+      />
     );
   },
 };


### PR DESCRIPTION
## 개요

range의 thumb을 custom한 div 태그로 사용하고 있었는데, custom thumb에서 input 태그에서 벗어난 곳을 클릭하면 range가 핸들링되지 않은 문제가 발생했다.
따라서 기존 브라우저의 range thumb을 사용하기로 결정했다.

## 작업 사항

- 브라우저의 range thumb을 사용
- 최댓값, 최솟값 표시
- storybook 수정
- 최댓값을 표시할 때, `+` 표시 여부를 나타내는 Prop추가
- 최솟값을 표시할 때, `-` 표시 여부를 나타내는 Prop추가

## 이슈 번호

close #77 