### PR TITLE
[FE] Modal 컴포넌트 리팩토링

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import { BackDrop, Description, ModalLayout, ModalWrapper, Title } from './style
 interface Props extends ComponentPropsWithoutRef<'div'> {
   isOpen: boolean;
   onClose: React.MouseEventHandler<HTMLElement>;
-  modalRootId: string;
+  modalRootId?: string;
   width?: string;
   height?: string;
   padding?: string;
@@ -39,7 +39,7 @@ const Modal = ({
         </ModalLayout>
       </ModalWrapper>
     </BackDrop>,
-    document.getElementById(modalRootId) as HTMLElement,
+    modalRootId ? (document.getElementById(modalRootId) as HTMLElement) : document.body,
   );
 };
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,7 +1,7 @@
-import React, { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { BackDrop, Description, ModalLayout, Title } from './style';
+import { BackDrop, Description, ModalLayout, ModalWrapper, Title } from './style';
 
 interface Props extends ComponentPropsWithoutRef<'div'> {
   isOpen: boolean;
@@ -21,15 +21,24 @@ const Modal = ({
   height = 'fit-content',
   padding = '1.25rem',
 }: Props) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
   if (!isOpen) return null;
 
   return createPortal(
-    <>
-      <ModalLayout $width={width} $height={height} $padding={padding}>
-        {children}
-      </ModalLayout>
-      <BackDrop onClick={onClose} />
-    </>,
+    <BackDrop
+      onClick={(e) => {
+        if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+          onClose(e);
+        }
+      }}
+    >
+      <ModalWrapper>
+        <ModalLayout ref={modalRef} $width={width} $height={height} $padding={padding}>
+          {children}
+        </ModalLayout>
+      </ModalWrapper>
+    </BackDrop>,
     document.getElementById(modalRootId) as HTMLElement,
   );
 };

--- a/src/components/Modal/style.ts
+++ b/src/components/Modal/style.ts
@@ -5,11 +5,6 @@ const ModalLayout = styled.div<{ $width?: string; $height?: string; $padding?: s
   flex-direction: column;
   align-items: center;
   gap: 1rem;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: ${({ theme }) => theme.zIndex.modal};
   width: ${({ $width }) => ($width ? $width : 'fit-content')};
   height: ${({ $height }) => ($height ? $height : 'fit-content')};
   padding: ${({ $padding }) => ($padding ? $padding : '1.25rem')};
@@ -17,6 +12,14 @@ const ModalLayout = styled.div<{ $width?: string; $height?: string; $padding?: s
   background-color: ${({ theme }) => theme.color.neutral.bg.default};
   border-radius: 0.75rem;
   box-shadow: 0 0 24px -4px rgba(16, 24, 40, 0.1);
+`;
+
+const ModalWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: fit-content;
+  min-height: 100vh;
 `;
 
 const Title = styled.span`
@@ -35,8 +38,11 @@ const BackDrop = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
+  overflow: auto;
+
   background-color: rgb(0 0 0 / 0.5);
-  z-index: ${({ theme }) => theme.zIndex.backDrop};
+
+  z-index: ${({ theme }) => theme.zIndex.modal};
 `;
 
-export { ModalLayout, Title, Description, BackDrop };
+export { ModalLayout, ModalWrapper, Title, Description, BackDrop };

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof Modal> = {
       description: '모달이 현재 표시되고 있는지 여부를 나타냅니다.',
     },
     modalRootId: {
-      description: '모달이 위치할 element의 id를 적어주세요.',
+      description: '모달이 위치할 element의 id를 적어주세요. (기본값은 body에 위치합니다.)',
     },
     children: {
       description: '모달의 컨텐츠를 설정합니다.',
@@ -38,10 +38,7 @@ export default meta;
 type Story = StoryObj<typeof Modal>;
 
 export const Default: Story = {
-  argTypes: {
-    modalRootId: { control: { disable: true } },
-  },
-  render: ({ width, height, padding }) => {
+  render: ({ width, height, padding, modalRootId }) => {
     const { isOpen, open, close } = useModal();
 
     return (
@@ -52,7 +49,7 @@ export const Default: Story = {
         <Modal
           isOpen={isOpen}
           onClose={close}
-          modalRootId="modal-root"
+          modalRootId={modalRootId}
           width={width}
           height={height}
           padding={padding}


### PR DESCRIPTION
## 개요

## 작업 사항

- Modal 컴포넌트가 브라우저 창보다 클 경우, BackDrop에 스크롤이 생긴다.
- modalRootId를 입력하지 않을 경우, portal이 위치할 기본 root 요소는 document.body이다.

## 이슈 번호

close #106 
