### PR TITLE
[FE] main 브런치에 push 이벤트가 발생하면 npm 배포 관련 workflow 실행

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,8 +2,8 @@ name: Publish to npm
 
 on:
   push:
-    tags:
-      - v*.*.*
+    branches:
+      - main
 
 jobs:
   publish-npm:


### PR DESCRIPTION
## 개요

기존에는 tag가 push되면 배포됐으나, main에 push가 발생하면 배포되도록 변경했다.

- dev 브런치: 다음 버전을 위해 개발 중인 작업물을 저장
- main 브런치: 출시 가능한 브런치
  - tag로 패키지 버전 표시

## 작업 사항

## 이슈 번호
